### PR TITLE
fix: Fix dependencies installation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
         python-version: '3.10'
     - name: Install Dependencies
       shell: bash
-      run: pip install -r conda/requirements.txt
+      run: pip install "openai==0.27.*" "PyGithub~=1.57" "requests~=2.28.2"
 
     - name: Pass Inputs to Shell
       shell: bash


### PR DESCRIPTION
Fix the dependencies installation issue, where the requirements.txt was not available when using the github actions from outside.